### PR TITLE
Fixed GitHub icon being big and out of layout in Firefox

### DIFF
--- a/src/components/SocialIcons.js
+++ b/src/components/SocialIcons.js
@@ -33,7 +33,7 @@ const SocialIcons = props => (
         target="_blank"
         href="https://www.github.com/gillkyle"
       >
-        <FA.FaGithub size={'1.75rem'} />
+        <FA.FaGithub />
       </SocialIcon>
     </div>
     <Card padding="0.2rem 1rem">


### PR DESCRIPTION
Fixing this issue in Firefox v61.0:

![screenshot_2018-07-03 card surge](https://user-images.githubusercontent.com/23660003/42233413-c2613b9a-7f06-11e8-9907-e67fde0d2454.png)
